### PR TITLE
enable mobile data checkbox and fix crash

### DIFF
--- a/app/src/main/java/com/suyashsrijan/forcedoze/SettingsActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/SettingsActivity.java
@@ -420,9 +420,9 @@ public class SettingsActivity extends AppCompatActivity {
                 mainSettings.removePreference(enableSensors);
             }
 
-            if (!isSuAvailable) {
+            /*if (!isSuAvailable) {
                 dozeSettings.removePreference(turnOffDataInDoze);
-            }
+            }*/
 
         }
 
@@ -477,7 +477,9 @@ public class SettingsActivity extends AppCompatActivity {
                 @Override
                 public void onClick(DialogInterface dialogInterface, int i) {
                     dialogInterface.dismiss();
-                    ProcessPhoenix.triggerRebirth(getActivity());
+                    //ProcessPhoenix.triggerRebirth(getActivity());
+                    getActivity().finish(); //no restart
+                    Runtime.getRuntime().exit(0); //just exit, still restarts or keep active though...
                 }
             });
             builder.show();


### PR DESCRIPTION
Sometimes the mobile data checkbox would be disabled even when root was available, this makes the option always available.
ProcessPhoenix is no longer used on reset as it could make the app/service crash.

However crashing the app/service is what can fix the mobile data checkbox being wrongly removed.
